### PR TITLE
Fixed Issue #6 regarding state in reverseGeocode

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,7 +248,7 @@ Geocoder.prototype = {
 
           client.query({name:"tiger_reverse_geocode", text: "SELECT (pprint_addy(rg.addy[1])) as normalized_address, $1 as lat, $2 as lon, "+
           "rg.addy[1].address As streetnumber, rg.addy[1].streetname As street, "+
-          "rg.addy[1].streettypeabbrev As styp, rg.addy[1].location As city, rg.addy[1].stateabbrev As st, rg.addy[1].zip "+
+          "rg.addy[1].streettypeabbrev As styp, rg.addy[1].location As city, rg.addy[1].stateabbrev As state, rg.addy[1].zip "+
           "FROM reverse_geocode(ST_SetSRID(ST_Point($2, $1),4326)) rg LIMIT $3",
             values:[lat, lng, options.limitResults]}, function(err, results){
             done();


### PR DESCRIPTION
Fixed query to return stateabbrev as state so that parseResult properly includes the 'state' in the response returned.
